### PR TITLE
feat: 회원가입/로그인 백엔드 API 재연동

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,6 +6,7 @@ import type {
   SignupResponse,
   ExpertSignupRequest,
   ExpertSignupResponse,
+  CommonResponse,
 } from './types';
 
 export const login = async (data: LoginRequest): Promise<LoginResponse> => {
@@ -28,4 +29,18 @@ export const expertSignup = async (
 
 export const withdraw = async (userId: number): Promise<void> => {
   await axiosInstance.patch(`/withdraw/${userId}`);
+};
+
+export const generateVerificationCode = async (phoneNum: string): Promise<CommonResponse> => {
+  const response = await axiosInstance.post<CommonResponse>('/generate', null, {
+    params: { phoneNum },
+  });
+  return response.data;
+};
+
+export const verifyCode = async (phoneNum: string, inputCode: string): Promise<CommonResponse> => {
+  const response = await axiosInstance.post<CommonResponse>('/verify', null, {
+    params: { phoneNum, inputCode },
+  });
+  return response.data;
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -18,11 +18,11 @@ export interface LoginResponse {
 
 export interface SignupRequest {
   name: string;
-  birth: string;
+  birth: string; // "YYYY-MM-DD" 형식
   gender: 'MALE' | 'FEMALE';
   email: string;
   password: string;
-  phone: string;
+  phone: string; // -없이 숫자만
 }
 
 export interface SignupResponse {
@@ -49,4 +49,18 @@ export interface ExpertSignupResponse {
     expertId: number;
     createdAt: string;
   };
+}
+
+export interface CommonResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: string;
+}
+
+export interface ErrorResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  data?: unknown;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react({
@@ -15,4 +14,14 @@ export default defineConfig({
     svgr(),
     tsconfigPaths(),
   ],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://43.201.137.131:8080',
+        changeOrigin: true,
+        ws: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 🚀 관련이슈
#12

## 📝 작업내용
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
-axios interceptor 수정하여 인증이 필요없는 엔드포인트 목록 추가 
-백엔드 API 재연동을 위한 vite.config.ts 프록시 설정 추가 
-회원가입 시 휴대폰 인증번호 발송 및 검증 로직 구현 -auth.ts에서 API 요청 로직 수정 
-401 Unauthorized, CORS 이슈 해결

## ✔️ 체크 리스트

- [ ]  Merge 하려는 브랜치가 올바른가? (main branch에 실수로 PR 생성 금지)
- [ ]  Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

## 📸 스크린샷
없음

## 💬 공유사항 to 리뷰어
-인증이 필요하지 않은 엔드포인트들(/generate, /verify, /user/join, /login)에 대해서는 토큰 검증을 하지 않도록 처리했습니다.
 -CORS 이슈 해결을 위해 프록시 설정을 추가했습니다.
